### PR TITLE
타우리 빌드 환경에서 api call이 되지 않던 현상 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "lint-staged": "lint-staged",
-    "prepare": "husky"
+    "prepare": "husky",
+    "proxy": "http://118.67.131.212:9999"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [
@@ -29,6 +30,7 @@
     "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {
+    "@tauri-apps/api": "^1.6.0",
     "@tauri-apps/cli": "^1.5.12",
     "@types/node": "^20.11.25",
     "@types/react": "^18.2.56",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,11 @@
     "allowlist": {
       "http": {
         "all": true,
-        "request": true
+        "request": true,
+        "scope": [
+          "http://118.67.131.212:9999/scenarios",
+          "http://localhost:56320"
+        ]
       }
     },
     "bundle": {
@@ -45,7 +49,7 @@
       "targets": "all",
       "windows": {
         "webviewInstallMode": {
-          "type": "offlineInstaller"
+          "type": "embedBootstrapper"
         },
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",

--- a/src/api/acryl.ts
+++ b/src/api/acryl.ts
@@ -1,11 +1,17 @@
 import { END_POINT } from '@constants/api';
-import axios from 'axios';
+import { fetch } from '@tauri-apps/api/http';
 
 export const postAccidentData = async (data: string) => {
   try {
-    const response = await axios.post(END_POINT.ACRYL, {
-      content: data,
-      layer: [1, 2, 3, 4, 5],
+    const response = await fetch(END_POINT.ACRYL, {
+      method: 'POST',
+      body: {
+        type: 'Text',
+        payload: {
+          content: data,
+          layer: [1, 2, 3, 4, 5],
+        },
+      },
     });
 
     return response;

--- a/src/api/scenario.ts
+++ b/src/api/scenario.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 
 export const postSaveScenarios = async (data: string) => {
   try {
-    const response = await axios.post(END_POINT.SAVE, JSON.parse(data));
+    const parsedData = JSON.parse(data);
+    const response = await axios.post(END_POINT.TEST_CASE, parsedData);
 
     return response;
   } catch (e) {
@@ -13,7 +14,7 @@ export const postSaveScenarios = async (data: string) => {
 
 export const deleteScenarios = async () => {
   try {
-    const res = await axios.post(END_POINT.DELETE);
+    const res = await axios.delete(END_POINT.TEST_CASE);
 
     return res;
   } catch (e) {

--- a/src/api/scenario.ts
+++ b/src/api/scenario.ts
@@ -1,12 +1,18 @@
 import { END_POINT } from '@constants/api';
-import axios from 'axios';
+import { fetch } from '@tauri-apps/api/http';
 
 export const postSaveScenarios = async (data: string) => {
   try {
     const parsedData = JSON.parse(data);
-    const response = await axios.post(END_POINT.TEST_CASE, parsedData);
+    const res = await fetch(END_POINT.TEST_CASE, {
+      method: 'POST',
+      body: {
+        type: 'Json',
+        payload: parsedData,
+      },
+    });
 
-    return response;
+    return res;
   } catch (e) {
     console.log(e);
   }
@@ -14,7 +20,9 @@ export const postSaveScenarios = async (data: string) => {
 
 export const deleteScenarios = async () => {
   try {
-    const res = await axios.delete(END_POINT.TEST_CASE);
+    const res = await fetch(END_POINT.TEST_CASE, {
+      method: 'DELETE',
+    });
 
     return res;
   } catch (e) {

--- a/src/components/common/Modal/AccidentModal.tsx
+++ b/src/components/common/Modal/AccidentModal.tsx
@@ -5,10 +5,10 @@ import { useCallback, useState } from 'react';
 import { postAccidentData } from '@api/acryl';
 import { useSetSelectedCaseStore } from '@store/selected-case';
 import { matchingCaseWithResponse } from '@utils/element';
-import { AxiosResponse } from 'axios';
 import { responseDataType } from '@type/element';
 import { useSetLoadingStateStore } from '@store/loading';
 import { message } from '@utils/toast';
+import { Response } from '@tauri-apps/api/http';
 
 const AccidentModal = () => {
   const setModal = useSetSelectedModalStore();
@@ -35,7 +35,7 @@ const AccidentModal = () => {
       // postData 함수의 결과가 Promise이므로 await을 사용하여 결과를 기다립니다.
       const responseData = await postAccidentData(accidentData);
       const processedData = matchingCaseWithResponse(
-        responseData as AxiosResponse<responseDataType>,
+        responseData as Response<responseDataType>,
       );
       setModal('none');
       setSelectedCase(processedData);

--- a/src/components/home/SaveButton/SaveButton.tsx
+++ b/src/components/home/SaveButton/SaveButton.tsx
@@ -13,7 +13,7 @@ const SaveButton = () => {
 
   const handleSaveButtonClick = async () => {
     if (isEmpty) {
-      alert('생성된 시나리오가 없습니다.');
+      message('생성된 시나리오가 없습니다.');
     }
 
     try {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,5 +1,5 @@
 export const END_POINT = {
   ACRYL: 'http://seven.acryl.ai:39500/ner',
-  SAVE: 'http://118.67.131.212:9999/scenarios',
+  TEST_CASE: 'http://118.67.131.212:9999/scenarios',
   DELETE: 'http://118.67.131.212:9999/scenarios',
 } as const;

--- a/src/mocks/elementData.ts
+++ b/src/mocks/elementData.ts
@@ -691,7 +691,7 @@ export const elementData: ElementType[] = [
   {
     id: 130,
     type: 'case',
-    value: '신호 영향 없음',
+    value: '우회전',
     parentId: 87,
     name: '차량신호',
     layer: 2,

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -1,3 +1,4 @@
+import { Response } from '@tauri-apps/api/http';
 import { ParsedElement } from './../types/element';
 import { elementData, memoCases } from '@mocks/elementData';
 import { RandomType } from '@type/common';
@@ -8,7 +9,6 @@ import type {
   TestCase,
   responseDataType,
 } from '@type/element';
-import { AxiosResponse } from 'axios';
 
 /**
  * 레이어 ID를 받아서 해당 레이어의 하위 레이어를 찾아서 트리 구조로 반환하는 함수
@@ -81,7 +81,7 @@ export async function createTestCases(
  * 입력받은 데이터를 아크릴 측으로 전송합니다
  */
 export function matchingCaseWithResponse(
-  res: AxiosResponse<responseDataType>,
+  res: Response<responseDataType>,
 ): ElementType[] {
   const result: ElementType[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,6 +744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tauri-apps/api@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@tauri-apps/api@npm:1.6.0"
+  checksum: 10c0/c3d9a0126093061b95c968d346dc47bb3ca99056a3b03b53b9f8d8f37c539479298495b79df095c2745a10dcbd4e40e161ec4b148819df2acfa20fa61845001b
+  languageName: node
+  linkType: hard
+
 "@tauri-apps/cli-darwin-arm64@npm:1.5.12":
   version: 1.5.12
   resolution: "@tauri-apps/cli-darwin-arm64@npm:1.5.12"
@@ -3567,6 +3574,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kgu-scenario-web@workspace:."
   dependencies:
+    "@tauri-apps/api": "npm:^1.6.0"
     "@tauri-apps/cli": "npm:^1.5.12"
     "@types/node": "npm:^20.11.25"
     "@types/react": "npm:^18.2.56"


### PR DESCRIPTION
## Summary

> 개발 환경이 아닌 Tauri를 통해 빌드 된 애플리케이션에서 api call이 작동하지 않던 현상을 해결했어요.

## Tasks

- 테스트 케이스 저장 및 아크릴 통신에서 axios → fetch (Tauri 자체) 로 대체
- proxy 설정
- end-point 통합
